### PR TITLE
uffd: new uffd_open param to print info/error

### DIFF
--- a/criu/include/uffd.h
+++ b/criu/include/uffd.h
@@ -3,7 +3,7 @@
 
 struct task_restore_args;
 
-extern int uffd_open(int flags, unsigned long *features);
+extern int uffd_open(int flags, unsigned long *features, bool userfaultfd_ok_to_fail);
 extern bool uffd_noncooperative(void);
 extern int setup_uffd(int pid, struct task_restore_args *task_args);
 extern int lazy_pages_setup_zombie(int pid);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -900,7 +900,7 @@ static int kerndat_uffd(void)
 	int uffd;
 
 	kdat.uffd_features = 0;
-	uffd = uffd_open(0, &kdat.uffd_features);
+	uffd = uffd_open(0, &kdat.uffd_features, true);
 
 	/*
 	 * uffd == -ENOSYS means userfaultfd is not supported on this

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -262,14 +262,18 @@ static int uffd_api_ioctl(void *arg, int fd, pid_t pid)
 	return ioctl(fd, UFFDIO_API, uffdio_api);
 }
 
-int uffd_open(int flags, unsigned long *features)
+int uffd_open(int flags, unsigned long *features, bool userfaultfd_ok_to_fail)
 {
 	struct uffdio_api uffdio_api = { 0 };
 	int uffd;
 
 	uffd = syscall(SYS_userfaultfd, flags);
 	if (uffd == -1) {
-		pr_perror("Lazy pages are not available");
+		if (userfaultfd_ok_to_fail) {
+			pr_info("Lazy pages are not available: %s\n", strerror(errno));
+		} else {
+			pr_perror("Lazy pages are not available");
+		}
 		return -errno;
 	}
 
@@ -313,7 +317,7 @@ int setup_uffd(int pid, struct task_restore_args *task_args)
 	 * Open userfaulfd FD which is passed to the restorer blob and
 	 * to a second process handling the userfaultfd page faults.
 	 */
-	task_args->uffd = uffd_open(O_CLOEXEC | O_NONBLOCK, &features);
+	task_args->uffd = uffd_open(O_CLOEXEC | O_NONBLOCK, &features, false);
 	if (task_args->uffd < 0) {
 		pr_perror("Unable to open an userfaultfd descriptor");
 		return -1;


### PR DESCRIPTION
uffd: add if on uffd_open flags to determine pr_info or perror

BEFORE PATCH APPLICATION:
On sys_userfaultfd() failure, a perror message is always displayed.

AFTER PATCH APPLICATION:
In addition to indicating unavailable lazy pages, the new LOC's checks the uffd_open flags and calls pr_info when called by kerndat and perror otherwise. 