### PR TITLE
Add error logging to config + crtools init

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -587,8 +587,10 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			opts.final_state = TASK_ALIVE;
 			break;
 		case 'x':
-			if (optarg && unix_sk_ids_parse(optarg) < 0)
+			if (optarg && unix_sk_ids_parse(optarg) < 0) {
+				pr_err("Failed to parse unix socket inode from optarg: %s\n", optarg);
 				return 1;
+			}
 			opts.ext_unix_sk = true;
 			break;
 		case 't':
@@ -648,13 +650,17 @@ int parse_options(int argc, char **argv, bool *usage_error,
 					goto bad_arg;
 
 				*aux = '\0';
-				if (veth_pair_add(optarg, aux + 1))
+				if (veth_pair_add(optarg, aux + 1)) {
+					pr_err("Failed to add veth pair: %s, %s.\n", optarg, aux + 1);
 					return 1;
+				}
 			}
 			break;
 		case 1049:
-			if (add_script(optarg))
+			if (add_script(optarg)) {
+				pr_err("Failed to add action-script: %s.\n", optarg);
 				return 1;
+			}
 			break;
 		case 1051:
 			SET_CHAR_OPTS(addr, optarg);
@@ -724,12 +730,16 @@ int parse_options(int argc, char **argv, bool *usage_error,
 				return 0;
 			break;
 		case 1064:
-			if (!add_skip_mount(optarg))
+			if (!add_skip_mount(optarg)) {
+				pr_err("Failed to add skip-mnt: %s\n", optarg);
 				return 1;
+			}
 			break;
 		case 1065:
-			if (!add_fsname_auto(optarg))
+			if (!add_fsname_auto(optarg)) {
+				pr_err("Failed while parsing --enable-fs option: %s", optarg);
 				return 1;
+			}
 			break;
 		case 1068:
 			SET_CHAR_OPTS(freeze_cgroup, optarg);
@@ -738,8 +748,10 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			opts.ghost_limit = parse_size(optarg);
 			break;
 		case 1070:
-			if (irmap_scan_path_add(optarg))
+			if (irmap_scan_path_add(optarg)) {
+				pr_err("Failed while parsing --irmap-scan-path option: %s", optarg);
 				return -1;
+			}
 			break;
 		case 1071:
 			SET_CHAR_OPTS(lsm_profile, optarg);
@@ -765,13 +777,17 @@ int parse_options(int argc, char **argv, bool *usage_error,
 					goto bad_arg;
 
 				*aux = '\0';
-				if (ext_mount_add(optarg, aux + 1))
+				if (ext_mount_add(optarg, aux + 1)) {
+					pr_err("Could not add external mount when initializing config: %s, %s\n", optarg, aux + 1);
 					return 1;
+				}
 			}
 			break;
 		case 1073:
-			if (add_external(optarg))
+			if (add_external(optarg)) {
+				pr_err("Could not add external resource when initializing config: %s\n", optarg);
 				return 1;
+			}
 			break;
 		case 1074:
 			if (!strcmp("net", optarg))

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -69,8 +69,10 @@ int main(int argc, char *argv[], char *envp[])
 	BUG_ON(get_service_fd(SERVICE_FD_MIN+1) <
 	       get_service_fd(SERVICE_FD_MAX-1));
 
-	if (fault_injection_init())
+	if (fault_injection_init()) {
+		pr_err("Failed to initialize fault injection when initializing crtools.\n");
 		return 1;
+	}
 
 	cr_pb_init();
 	setproctitle_init(argc, argv, envp);
@@ -153,8 +155,10 @@ int main(int argc, char *argv[], char *envp[])
 	/* We must not open imgs dir, if service is called */
 	if (strcmp(argv[optind], "service")) {
 		ret = open_image_dir(opts.imgs_dir);
-		if (ret < 0)
+		if (ret < 0) {
+			pr_err("Couldn't open image dir: %s", opts.imgs_dir);
 			return 1;
+		}
 	}
 
 	/*
@@ -187,8 +191,10 @@ int main(int argc, char *argv[], char *envp[])
 	if (log_init(opts.output))
 		return 1;
 
-	if (kerndat_init())
+	if (kerndat_init()) {
+		pr_err("Could not initialize kernel features detection.\n");
 		return 1;
+	}
 
        if (fault_injected(FI_CANNOT_MAP_VDSO))
                kdat.can_map_vdso = 0;

--- a/criu/fault-injection.c
+++ b/criu/fault-injection.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include "criu-log.h"
 #include "fault-injection.h"
 
 enum faults fi_strategy;
@@ -14,8 +15,10 @@ int fault_injection_init(void)
 
 	start = atoi(val);
 
-	if (start <= 0 || start >= FI_MAX)
+	if (start <= 0 || start >= FI_MAX) {
+		pr_err("CRIU_FAULT out of bounds.\n");
 		return -1;
+	}
 
 	fi_strategy = start;
 	return 0;

--- a/criu/image.c
+++ b/criu/image.c
@@ -580,8 +580,10 @@ int open_image_dir(char *dir)
 	}
 
 	ret = install_service_fd(IMG_FD_OFF, fd);
-	if (ret < 0)
+	if (ret < 0) {
+		pr_err("install_service_fd failed.\n");
 		return -1;
+	}
 	fd = ret;
 
 	if (opts.remote) {

--- a/criu/include/criu-log.h
+++ b/criu/include/criu-log.h
@@ -21,6 +21,7 @@
 #define __CRIU_LOG_H__
 
 #include "log.h"
+#include <sys/types.h>
 
 struct timeval;
 


### PR DESCRIPTION
CRIU sometimes returns 1 from main() "with no explanation. Even increasing the log level didn't help, because that was not set until after some initialization." Changes made add more logging in the case of initialization errors.

Signed-off-by: Angie Ni <avtni@google.com>