### PR TITLE
uffd: uffd_open caller prints info/error instead 

### DIFF
--- a/criu/include/uffd.h
+++ b/criu/include/uffd.h
@@ -3,7 +3,7 @@
 
 struct task_restore_args;
 
-extern int uffd_open(int flags, unsigned long *features, bool userfaultfd_ok_to_fail);
+extern int uffd_open(int flags, unsigned long *features);
 extern bool uffd_noncooperative(void);
 extern int setup_uffd(int pid, struct task_restore_args *task_args);
 extern int lazy_pages_setup_zombie(int pid);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -900,7 +900,7 @@ static int kerndat_uffd(void)
 	int uffd;
 
 	kdat.uffd_features = 0;
-	uffd = uffd_open(0, &kdat.uffd_features, true);
+	uffd = uffd_open(0, &kdat.uffd_features);
 
 	/*
 	 * uffd == -ENOSYS means userfaultfd is not supported on this
@@ -911,8 +911,7 @@ static int kerndat_uffd(void)
 	if (uffd < 0) {
 		if (uffd == -ENOSYS)
 			return 0;
-
-		pr_err("Lazy pages are not available\n");
+		pr_perror("Unable to open an userfaultfd descriptor");
 		return -1;
 	}
 


### PR DESCRIPTION
When uffd_open is called from kerndat_uffd, userfaultfd failiure is not
considered an error, so the goal is to suppress the error message --
instead, the goal of this change is to print this message as info.

Initially, uffd_open handles userfaultfd fails with errors only, but this
implementation distinguishes whether to report as an error or info
depending on where uffd_open was called.

Signed-off-by: Angie Ni <avtni@google.com>