### PR TITLE
Restructured getgroups check out of PIE

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3129,21 +3129,21 @@ static void rst_reloc_creds(struct thread_restore_args *thread_args,
 }
 
 static bool groups_are_okay(gid_t* groups, int n_groups) {
-	int check_num_groups, gids_len;
-	bool groups_are_ok;
+	int n, len;
+	bool ret;
 	gid_t* gids;
 
-	check_num_groups = getgroups(0, NULL);
-	if (check_num_groups != n_groups)
+	n = getgroups(0, NULL);
+	if (n != n_groups)
 		return false;
-	if (check_num_groups == 0)
+	if (n == 0)
 		return true;
-	gids_len = check_num_groups * sizeof(unsigned int);
-	gids = (gid_t*)xmalloc(gids_len * sizeof(gid_t));
-	check_num_groups = getgroups(check_num_groups, gids);
-	groups_are_ok = !memcmp(gids, groups, gids_len);
+	len = n * sizeof(gid_t);
+	gids = (gid_t*)xmalloc(len);
+	n = getgroups(n, gids);
+	ret = !memcmp(gids, groups, len);
 	xfree(gids);
-	return groups_are_ok;
+	return ret;
 }
 
 static struct thread_creds_args *

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -202,32 +202,10 @@ static int restore_creds(struct thread_creds_args *args, int procfd,
 	 * Setup supplementary group IDs early.
 	 */
 	if (args->groups) {
-		// We may be in an unprivileged user namespace where we're not
-		// allowed to call setgroups. If the current list of groups is already
-		// what we want, skip the call to setgroups.
-
-		int n = sys_getgroups(0, NULL);
-		int len = n * sizeof(unsigned int);
-		bool groups_are_ok;
-		unsigned int* gids = (unsigned int*)sys_mmap(NULL, len, PROT_WRITE | PROT_READ,
-			MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-		if (gids == MAP_FAILED) {
-			pr_err("Unable to mmap %d bytes\n", len);
+		ret = sys_setgroups(ce->n_groups, args->groups);
+		if (ret) {
+			pr_err("Can't setup supplementary group IDs: %d\n", ret);
 			return -1;
-		}
-		n = sys_getgroups(n, gids);
-		groups_are_ok = (n == ce->n_groups && !memcmp(gids, args->groups, len));
-		if (sys_munmap(gids, len)) {
-			pr_err("Unable to munmap\n");
-			return -1;
-		}
-		if (groups_are_ok) {
-			pr_debug("getgroups() looks good, not calling setgroups()\n");
-		} else {
-			if (sys_setgroups(ce->n_groups, args->groups)) {
-				pr_err("Can't setgroups([%zu gids])\n", ce->n_groups);
-				return -1;
-			}
 		}
 	}
 


### PR DESCRIPTION
Previously, changes made would check the necessity of calling setgroups
in restorer.c of pie. This commit relocates this check to criu/restore.c
before restore_creds occurs.

Signed-off-by: Angie Ni <avtni@google.com>