### PR TITLE
Modify CRIU to dump + restore thread cgroups

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -716,32 +716,31 @@ static int collect_cgroups(struct list_head *ctls)
 	return 0;
 }
 
-int dump_task_cgroup(struct pstree_item *item, u32 *cg_id, struct parasite_dump_cgroup_args *args)
+int dump_task_cgroup(struct pid *item_pid, u32 *cg_id, struct parasite_dump_cgroup_args *args)
 {
 	int pid;
 	LIST_HEAD(ctls);
 	unsigned int n_ctls = 0;
 	struct cg_set *cs;
 
-	if (item)
-		pid = item->pid->real;
+	if (item_pid)
+		pid = item_pid->real;
 	else
 		pid = getpid();
-
 	pr_info("Dumping cgroups for %d\n", pid);
 	if (parse_task_cgroup(pid, args, &ctls, &n_ctls))
 		return -1;
 
-	cs = get_cg_set(&ctls, n_ctls, item);
+	cs = get_cg_set(&ctls, n_ctls, item_pid);
 	if (!cs)
 		return -1;
 
-	if (!item) {
+	if (!item_pid) {
 		BUG_ON(criu_cgset);
 		criu_cgset = cs;
 		pr_info("Set %d is criu one\n", cs->id);
 	} else {
-		if (item == root_item) {
+		if (item_pid == root_item->pid) {
 			BUG_ON(root_cgset);
 			root_cgset = cs;
 			pr_info("Set %d is root one\n", cs->id);

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1207,32 +1207,21 @@ static int move_in_cgroup(CgSetEntry *se, bool setup_cgns)
 	return 0;
 }
 
-int prepare_task_cgroup(struct pstree_item *me)
+int prepare_task_cgroup(u32 cg_set, u32 ancestor_cg_set, bool is_root_task)
 {
-	struct pstree_item *parent = me->parent;
 	CgSetEntry *se;
-	u32 current_cgset;
 
-	if (!rsti(me)->cg_set)
+	if (!cg_set)
 		return 0;
 
-	/* Zombies and helpers can have cg_set == 0 so we skip them */
-	while (parent && !rsti(parent)->cg_set)
-		parent = parent->parent;
-
-	if (parent)
-		current_cgset = rsti(parent)->cg_set;
-	else
-		current_cgset = root_cg_set;
-
-	if (rsti(me)->cg_set == current_cgset) {
-		pr_info("Cgroups %d inherited from parent\n", current_cgset);
+	if (cg_set == ancestor_cg_set) {
+		pr_info("Cgroups %d inherited from parent\n", ancestor_cg_set);
 		return 0;
 	}
 
-	se = find_rst_set_by_id(rsti(me)->cg_set);
+	se = find_rst_set_by_id(cg_set);
 	if (!se) {
-		pr_err("No set %d found\n", rsti(me)->cg_set);
+		pr_err("No set %d found\n", cg_set);
 		return -1;
 	}
 
@@ -1241,8 +1230,7 @@ int prepare_task_cgroup(struct pstree_item *me)
 	 * just check that the cgns prefix string matches for all the entries
 	 * in the cgset, and only unshare if that's true.
 	 */
-
-	return move_in_cgroup(se, !me->parent);
+	return move_in_cgroup(se, is_root_task);
 }
 
 void fini_cgroup(void)

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1409,8 +1409,6 @@ static int dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie)
 		goto err_cure;
 	}
 
-	pr_info("avtni@ Successfully dumped threads for pid: %d\n", item->pid->real);
-
 	/*
 	 * On failure local map will be cured in cr_dump_finish()
 	 * for lazy pages.

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -64,6 +64,7 @@
 #include "kerndat.h"
 #include "stats.h"
 #include "mem.h"
+#include "pid.h"
 #include "page-pipe.h"
 #include "posix-timer.h"
 #include "vdso.h"
@@ -782,7 +783,7 @@ static int dump_task_core_all(struct parasite_ctl *ctl,
 	}
 
 	core->tc->has_cg_set = true;
-	ret = dump_task_cgroup(item, &core->tc->cg_set, info);
+	ret = dump_task_cgroup(item->pid, &core->tc->cg_set, info);
 	if (ret)
 		goto err;
 
@@ -846,6 +847,7 @@ static int dump_task_thread(struct parasite_ctl *parasite_ctl,
 				const struct pstree_item *item, int id)
 {
 	struct parasite_thread_ctl *tctl = dmpi(item)->thread_ctls[id];
+	struct parasite_dump_cgroup_args cgroup_args;
 	struct pid *tid = &item->threads[id];
 	CoreEntry *core = item->core[id];
 	pid_t pid = tid->real;
@@ -856,12 +858,18 @@ static int dump_task_thread(struct parasite_ctl *parasite_ctl,
 	pr_info("Dumping core for thread (pid: %d)\n", pid);
 	pr_info("----------------------------------------\n");
 
-	ret = parasite_dump_thread_seized(tctl, parasite_ctl, id, tid, core);
+	ret = parasite_dump_thread_seized(tctl, parasite_ctl, id, tid, core, &cgroup_args);
 	if (ret) {
 		pr_err("Can't dump thread for pid %d\n", pid);
 		goto err;
 	}
 	pstree_insert_pid(tid);
+
+	ret = dump_task_cgroup(tid, &core->thread_core->cg_set, &cgroup_args);
+	if (ret) {
+		pr_err("Can't dump thread cgroup for pid %d\n", pid);
+		goto err;
+	}
 
 	img = open_image(CR_FD_CORE, O_DUMP, tid->ns[0].virt);
 	if (!img)
@@ -1400,6 +1408,8 @@ static int dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie)
 		pr_err("Can't dump threads\n");
 		goto err_cure;
 	}
+
+	pr_info("avtni@ Successfully dumped threads for pid: %d\n", item->pid->real);
 
 	/*
 	 * On failure local map will be cured in cr_dump_finish()

--- a/criu/include/cgroup.h
+++ b/criu/include/cgroup.h
@@ -2,12 +2,13 @@
 #define __CR_CGROUP_H__
 
 #include "int.h"
+#include "pid.h"
 #include "images/core.pb-c.h"
 
 struct pstree_item;
 struct parasite_dump_cgroup_args;
 extern u32 root_cg_set;
-int dump_task_cgroup(struct pstree_item *, u32 *, struct parasite_dump_cgroup_args *args);
+int dump_task_cgroup(struct pid *, u32 *, struct parasite_dump_cgroup_args *args);
 int dump_cgroups(void);
 int prepare_task_cgroup(struct pstree_item *);
 int prepare_cgroup(void);

--- a/criu/include/cgroup.h
+++ b/criu/include/cgroup.h
@@ -10,7 +10,7 @@ struct parasite_dump_cgroup_args;
 extern u32 root_cg_set;
 int dump_task_cgroup(struct pid *, u32 *, struct parasite_dump_cgroup_args *args);
 int dump_cgroups(void);
-int prepare_task_cgroup(struct pstree_item *);
+int prepare_task_cgroup(u32 cg_set, u32 ancestor_cg_set, bool is_root_task);
 int prepare_cgroup(void);
 /* Restore things like cpu_limit in known cgroups. */
 int prepare_cgroup_properties(void);

--- a/criu/include/parasite-syscall.h
+++ b/criu/include/parasite-syscall.h
@@ -35,7 +35,7 @@ extern int parasite_dump_creds(struct parasite_ctl *ctl, struct _CredsEntry *ce)
 extern int parasite_dump_thread_leader_seized(struct parasite_ctl *ctl, int pid, struct _CoreEntry *core);
 extern int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl,
 				       struct parasite_ctl *ctl, int id,
-				       struct pid *tid, struct _CoreEntry *core);
+				       struct pid *tid, struct _CoreEntry *core, struct parasite_dump_cgroup_args *cgroup);
 extern int dump_thread_core(int pid, CoreEntry *core,
 					const struct parasite_dump_thread *dt);
 

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -162,9 +162,10 @@ int parasite_dump_thread_leader_seized(struct parasite_ctl *ctl, int pid, CoreEn
 
 int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl,
 				struct parasite_ctl *ctl, int id,
-				struct pid *tid, CoreEntry *core)
+				struct pid *tid, CoreEntry *core, struct parasite_dump_cgroup_args *cgroup)
 {
 	struct parasite_dump_thread *args;
+	struct parasite_dump_cgroup_args *cgargs;
 	pid_t pid = tid->real;
 	ThreadCoreEntry *tc = core->thread_core;
 	CredsEntry *creds = tc->creds;
@@ -173,11 +174,6 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl,
 
 	BUG_ON(id == 0); /* Leader is dumped in dump_task_core_all */
 
-	args = compel_parasite_args(ctl, struct parasite_dump_thread);
-
-	pc = args->creds;
-	pc->cap_last_cap = kdat.last_cap;
-
 	tc->has_blk_sigset = true;
 #ifdef CONFIG_MIPS
 	memcpy(&tc->blk_sigset, (unsigned long *)compel_thread_sigmask(tctl), sizeof(tc->blk_sigset));
@@ -185,11 +181,26 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl,
 #else
 	memcpy(&tc->blk_sigset, compel_thread_sigmask(tctl), sizeof(k_rtsigset_t));
 #endif
+
+	cgargs = compel_parasite_args(ctl, struct parasite_dump_cgroup_args);
+
+	ret = compel_run_in_thread(tctl, PARASITE_CMD_DUMP_CGROUP);
+	if (ret) {
+		pr_err("Can't dump thread cgroup %d\n", pid);
+		goto err_rth;
+	}
+	*cgroup = *cgargs;
+
 	ret = compel_get_thread_regs(tctl, save_task_regs, core);
 	if (ret) {
 		pr_err("Can't obtain regs for thread %d\n", pid);
 		goto err_rth;
 	}
+
+	args = compel_parasite_args(ctl, struct parasite_dump_thread);
+
+	pc = args->creds;
+	pc->cap_last_cap = kdat.last_cap;
 
 	ret = compel_run_in_thread(tctl, PARASITE_CMD_DUMP_THREAD);
 	if (ret) {
@@ -204,6 +215,7 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl,
 	}
 
 	compel_release_thread(tctl);
+	pr_info("avtni@ Parasite retrieved cgroup: %s\n", cgroup->contents);
 
 	tid->ns[0].virt = args->tid;
 	return dump_thread_core(pid, core, args);

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -215,7 +215,6 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl,
 	}
 
 	compel_release_thread(tctl);
-	pr_info("avtni@ Parasite retrieved cgroup: %s\n", cgroup->contents);
 
 	tid->ns[0].virt = args->tid;
 	return dump_thread_core(pid, core, args);

--- a/criu/pie/parasite.c
+++ b/criu/pie/parasite.c
@@ -652,10 +652,10 @@ static int parasite_dump_cgroup(struct parasite_dump_cgroup_args *args)
 		return -1;
 	}
 
-	cgroup = sys_openat(proc, "self/cgroup", O_RDONLY, 0);
+	cgroup = sys_openat(proc, "thread-self/cgroup", O_RDONLY, 0);
 	sys_close(proc);
 	if (cgroup < 0) {
-		pr_err("can't get /proc/self/cgroup fd\n");
+		pr_err("can't get /proc/thread-self/cgroup fd\n");
 		sys_close(cgroup);
 		return -1;
 	}
@@ -663,12 +663,12 @@ static int parasite_dump_cgroup(struct parasite_dump_cgroup_args *args)
 	len = sys_read(cgroup, args->contents, sizeof(args->contents));
 	sys_close(cgroup);
 	if (len < 0) {
-		pr_err("can't read /proc/self/cgroup %d\n", len);
+		pr_err("can't read /proc/thread-self/cgroup %d\n", len);
 		return -1;
 	}
 
 	if (len == sizeof(args->contents)) {
-		pr_warn("/proc/self/cgroup was bigger than the page size\n");
+		pr_warn("/proc/thread-self/cgroup was bigger than the page size\n");
 		return -1;
 	}
 
@@ -743,6 +743,8 @@ int parasite_trap_cmd(int cmd, void *args)
 	switch (cmd) {
 	case PARASITE_CMD_DUMP_THREAD:
 		return dump_thread(args);
+	case PARASITE_CMD_DUMP_CGROUP:
+		return parasite_dump_cgroup(args);
 	}
 
 	pr_err("Unknown command to parasite: %d\n", cmd);

--- a/images/core.proto
+++ b/images/core.proto
@@ -99,6 +99,7 @@ message thread_core_entry {
 
 	optional string			comm		= 13;
 	optional uint64			blk_sigset_extended	= 14;
+	optional uint32			cg_set		= 15;
 }
 
 message task_rlimits_entry {


### PR DESCRIPTION
Currently CRIU dump and restores only membership of processes in cgroups. Any information about membership of threads is lost, e.g. if a process is in cgroup “c1” and its thread is in cgroup “c2”, after C/R both will be in cgroup “c1” and cgroup “c2” won’t even exist on the restore machine. The objective is to fix that behaviour so that threads will be in the same cgroups after restore as they were before checkpoint.

Signed-off-by: Angie Ni <avtni@google.com>