### PR TITLE
Modified CRIU to restore thread cgroups

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -865,6 +865,7 @@ static int dump_task_thread(struct parasite_ctl *parasite_ctl,
 	}
 	pstree_insert_pid(tid);
 
+	core->thread_core->has_cg_set = true;
 	ret = dump_task_cgroup(tid, &core->thread_core->cg_set, &cgroup_args);
 	if (ret) {
 		pr_err("Can't dump thread cgroup for pid %d\n", pid);

--- a/criu/include/cgroup.h
+++ b/criu/include/cgroup.h
@@ -10,7 +10,7 @@ struct parasite_dump_cgroup_args;
 extern u32 root_cg_set;
 int dump_task_cgroup(struct pid *, u32 *, struct parasite_dump_cgroup_args *args);
 int dump_cgroups(void);
-int prepare_task_cgroup(u32 cg_set, u32 ancestor_cg_set, bool is_root_task);
+int prepare_task_cgroup(u32 cg_set, u32 ancestor_cg_set, bool is_root_task, pid_t pid);
 int prepare_cgroup(void);
 /* Restore things like cpu_limit in known cgroups. */
 int prepare_cgroup_properties(void);

--- a/test/zdtm/static/cgroup_threads.c
+++ b/test/zdtm/static/cgroup_threads.c
@@ -50,7 +50,7 @@ static int cg_check(char *name)
 	FILE *cgf;
 	char paux[256], aux[128];
 
-	cgf = fopen("/proc/self/cgroup", "r");
+	cgf = fopen("/proc/thread-self/cgroup", "r");
 	if (cgf == NULL)
 		return -1;
 


### PR DESCRIPTION
Updated `prepare_task_cgroups`, added data structs to represent thread/process ID's + their corresponding cgroup path, and modified the cgroup_threads test to compare the thread's cgroup.

Signed-off-by: Angie Ni <avtni@google.com>